### PR TITLE
Updated README to inform the users that the theme is currently not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![maintained](https://img.shields.io/maintenance/yes/2020?label=maintained&style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/commits/master) [![contributions](https://img.shields.io/badge/contribution-welcome-brightgreen&?style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/pulls) [![HitCount](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme.svg)](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/0812167ef9954b74ac23f7c1bfeb3764)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=manilarome/the-glorious-lightdm-webkit2-theme&amp;utm_campaign=Badge_Grade)
 
+## Attention: This theme is deprecated due to problems with the webkit2 greeter that for the time being is archived!
+
 A sleek, modern, and glorified lightdm webkit2 theme
 
 ## [Live Demo](https://manilarome.github.io/lightdm-webkit2-theme-glorious)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![maintained](https://img.shields.io/maintenance/yes/2020?label=maintained&style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/commits/master) [![contributions](https://img.shields.io/badge/contribution-welcome-brightgreen&?style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/pulls) [![HitCount](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme.svg)](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/0812167ef9954b74ac23f7c1bfeb3764)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=manilarome/the-glorious-lightdm-webkit2-theme&amp;utm_campaign=Badge_Grade)
 
-## Attention: This theme is deprecated due to problems with the webkit2 greeter that for the time being is archived!
+## Attention: This theme is deprecated due to problems with the webkit2 greeter which for the time being is archived!
 
 A sleek, modern, and glorified lightdm webkit2 theme
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![maintained](https://img.shields.io/maintenance/yes/2020?label=maintained&style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/commits/master) [![contributions](https://img.shields.io/badge/contribution-welcome-brightgreen&?style=flat-square)](https://github.com/manilarome/the-glorious-lightdm-webkit2-theme/pulls) [![HitCount](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme.svg)](http://hits.dwyl.com/manilarome/the-glorious-lightdm-webkit2-theme) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/0812167ef9954b74ac23f7c1bfeb3764)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=manilarome/the-glorious-lightdm-webkit2-theme&amp;utm_campaign=Badge_Grade)
 
-## Attention: This theme is deprecated due to problems with the webkit2 greeter which for the time being is archived!
+##  ⚠️ Attention: This theme is deprecated due to problems with the webkit2 greeter (see [here](https://bugs.archlinux.org/task/75988)) which for the time being is archived! The only workaround is [downgrading](https://github.com/archlinux-downgrade/downgrade) the webkit2 greeter to 2.36. 
 
 A sleek, modern, and glorified lightdm webkit2 theme
 


### PR DESCRIPTION
As disused to the issue [#74](https://github.com/manilarome/lightdm-webkit2-theme-glorious/issues/74) there has been problems with webkit2 and all of its greeters. Since it is an archived project I added a warning at the start of the README 