### PR TITLE
fix pam login after lock screen and add wheel event for open password field

### DIFF
--- a/js/authenticate.js
+++ b/js/authenticate.js
@@ -145,11 +145,9 @@ class Authenticate {
 		if (!lightdm) {
 			lightdm.onload = function() {
 				console.log('Start authentication');
-				this.startAuthentication();
 			};
 		} else {
 			console.log('Start authentication');
-			this.startAuthentication();
 		}
 	}
 }

--- a/js/greeter.js
+++ b/js/greeter.js
@@ -23,6 +23,16 @@ class GreeterScreen {
 	}
 
 	_arrowIndicatorClickEvent() {
+		document.addEventListener(
+			'wheel',
+			() => {
+				const start = !document.querySelector(".screen.background.screen-image.screen-background-darken.screen-greeter-hide")
+				if(start) {
+					this._hideGreeter();
+					this.startAuthentication();
+				}
+			}
+		);
 		this._arrowIndicatorGreeter.addEventListener(
 			'click',
 			() => {


### PR DESCRIPTION
I, as a user of a laptop with a touchpad, encountered a number of difficulties:
1. it is not convenient to click at the bottom of the screen to go to the password entry window(Added a swipe on the splash screen).
2. After installing face unlock (pam.d/lightdm), when the screen is locked, the recognition starts immediately, but I would like it when I try to log in (moved the authorization start)
ps: Maybe there is a better solution